### PR TITLE
Allow configuring individual team sizes

### DIFF
--- a/alias_war.html
+++ b/alias_war.html
@@ -82,10 +82,19 @@
         </div>
       </div>
 
-      <div class="settings-section">
-        <h4>Ajustes por ejército</h4>
-        <div id="teamsPanel" class="team-settings"></div>
-      </div>
+        <div class="settings-section">
+          <h4>Ajustes por ejército</h4>
+          <div id="teamsPanel" class="team-settings"></div>
+          <template id="teamRowTemplate">
+            <div class="teamRow">
+              <span class="dot"></span>
+              <strong class="teamName"></strong>
+              <input class="team-size" type="number" min="4" max="16" step="1" value="8"/>
+              <div class="bar" style="flex:1"><div class="fill"></div></div>
+              <span class="team-count" style="width:64px; text-align:right"></span>
+            </div>
+          </template>
+        </div>
 
       <div class="row">
         <div class="log" id="log"><div>[Sistema] Listo.</div></div>

--- a/main.js
+++ b/main.js
@@ -631,17 +631,17 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     }
   }
 
-  function buildTeams(n){
+  function buildTeams(sizes){
     teams = [];
-    const size = clamp(parseInt(ui.teamSize.value||8), 4, 16);
-    const comp = compositionFor(ui.composition.value, size);
-    for (let i=0;i<n;i++){
+    for (let i=0;i<sizes.length;i++){
       const meta = TEAM_META[i];
       teams.push({ id:i, name: meta.name, color: meta.color, units: [] });
     }
-    // distribuir ángulos
+    // distribuir ángulos y crear cada equipo con su tamaño
     for (let i=0;i<teams.length;i++){
       const ang = i * (Math.PI*2 / teams.length);
+      const size = clamp(parseInt(sizes[i])||8, 4, 16);
+      const comp = compositionFor(ui.composition.value, size);
       spawnTeam(teams[i], comp, ang);
     }
   }


### PR DESCRIPTION
## Summary
- Add HTML template and numeric inputs for per-army sizes
- Build teams using an array of custom sizes
- Read individual sizes in the UI and update team status accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2c4afd8883318a4248a5d4130943