### PR TITLE
feat: allow dynamic team size

### DIFF
--- a/alias_war.html
+++ b/alias_war.html
@@ -43,7 +43,7 @@
             </select>
           </div>
           <div>
-            <div class="kv"><span>Tamaño equipo</span><span class="mini">(4–16)</span></div>
+            <div class="kv"><span>Tamaño equipo</span><span class="mini"><span id="teamSizeLbl">8</span> (4–16)</span></div>
             <input id="teamSize" type="number" min="4" max="16" step="1" value="8" />
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -295,6 +295,7 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     speedLbl: document.getElementById('speedLbl'),
     composition: document.getElementById('composition'),
     teamSize: document.getElementById('teamSize'),
+    teamSizeLbl: document.getElementById('teamSizeLbl'),
     teamsCount: document.getElementById('teamsCount'),
     teamsLbl: document.getElementById('teamsLbl'),
     teamsPanel: document.getElementById('teamsPanel'),
@@ -305,6 +306,12 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
   ui.satellite.addEventListener('change', () => { controls.satellite = ui.satellite.checked; });
   controls.satellite = ui.satellite.checked;
   ui.teamsCount.addEventListener('input', ()=>{ ui.teamsLbl.textContent = ui.teamsCount.value; setupMatch(); });
+  ui.teamSize.addEventListener('input', () => {
+    const v = parseInt(ui.teamSize.value || 8);
+    ui.teamSizeLbl.textContent = v;
+    ui.teamsPanel.querySelectorAll('input.team-size').forEach(inp => { inp.value = v; });
+    setupMatch();
+  });
 
   function log(text){ const d = new Date().toLocaleTimeString(); ui.log.insertAdjacentHTML('beforeend', `<div>[${d}] ${text}</div>`); ui.log.scrollTop = ui.log.scrollHeight; }
 


### PR DESCRIPTION
## Summary
- trigger match rebuild when team size spinner changes and propagate value to per-team settings
- display current team size next to spinner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2df3ffc88331bc2d60bb1f792a45