### PR TITLE
feat: per-team composition selector

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -5,18 +5,22 @@ export function initAI(c){ ctx = c; }
 export function updateTeamCounts(){
   const { ui, teams } = ctx;
   const box = ui.teamsPanel;
-  const prev = Array.from(box.querySelectorAll('input.team-size')).map(i=>parseInt(i.value));
+  const prevSizes = Array.from(box.querySelectorAll('input.team-size')).map(i=>parseInt(i.value));
+  const prevComps = Array.from(box.querySelectorAll('select.team-comp')).map(s=>s.value);
   box.innerHTML = "";
   const tpl = document.getElementById('teamRowTemplate');
   for (let i=0;i<teams.length;i++){
     const t = teams[i];
-    const total = prev[i] || t.units.length;
+    const total = prevSizes[i] || t.units.length;
+    const compVal = prevComps[i] || ui.composition.value;
     const alive = t.units.filter(u=>u.userData.alive).length;
     const row = tpl.content.firstElementChild.cloneNode(true);
     row.querySelector('.dot').style.background = `#${t.color.toString(16).padStart(6,'0')}`;
     row.querySelector('.teamName').textContent = t.name;
     const inp = row.querySelector('.team-size');
     inp.value = total;
+    const sel = row.querySelector('.team-comp');
+    sel.value = compVal;
     row.querySelector('.fill').style.width = `${(100*alive/total).toFixed(1)}%`;
     row.querySelector('.team-count').textContent = `${alive}/${total}`;
     box.appendChild(row);
@@ -30,15 +34,21 @@ export function setupMatch(){
 
   const n = parseInt(ui.teamsCount.value||2);
   const inputs = ui.teamsPanel.querySelectorAll('input.team-size');
-  const def = parseInt(ui.teamSize.value||8);
-  const sizes = [];
+  const selects = ui.teamsPanel.querySelectorAll('select.team-comp');
+  const defSize = parseInt(ui.teamSize.value||8);
+  const defComp = ui.composition.value;
+  const configs = [];
   for (let i=0;i<n;i++){
     const v = parseInt(inputs[i]?.value);
-    sizes.push(isNaN(v) ? def : v);
+    const comp = selects[i]?.value;
+    configs.push({
+      size: isNaN(v) ? defSize : v,
+      comp: comp || defComp,
+    });
   }
 
   clearUnits();
-  buildTeams(sizes);
+  buildTeams(configs);
   allUnits.forEach(updateHPBar);
   updateTeamCounts();
 }

--- a/alias_war.html
+++ b/alias_war.html
@@ -90,6 +90,13 @@
               <span class="dot"></span>
               <strong class="teamName"></strong>
               <input class="team-size" type="number" min="4" max="16" step="1" value="8"/>
+              <select class="team-comp">
+                <option value="balanced">Equilibrada (8)</option>
+                <option value="melee">Cuerpo a cuerpo (8)</option>
+                <option value="ranged">A distancia (8)</option>
+                <option value="support">Soporte (8)</option>
+                <option value="random">Aleatoria (8)</option>
+              </select>
               <div class="bar" style="flex:1"><div class="fill"></div></div>
               <span class="team-count" style="width:64px; text-align:right"></span>
             </div>

--- a/main.js
+++ b/main.js
@@ -312,6 +312,11 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     ui.teamsPanel.querySelectorAll('input.team-size').forEach(inp => { inp.value = v; });
     setupMatch();
   });
+  ui.composition.addEventListener('change', () => {
+    const val = ui.composition.value;
+    ui.teamsPanel.querySelectorAll('select.team-comp').forEach(sel => { sel.value = val; });
+    setupMatch();
+  });
 
   function log(text){ const d = new Date().toLocaleTimeString(); ui.log.insertAdjacentHTML('beforeend', `<div>[${d}] ${text}</div>`); ui.log.scrollTop = ui.log.scrollHeight; }
 
@@ -638,17 +643,19 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     }
   }
 
-  function buildTeams(sizes){
+  function buildTeams(configs){
     teams = [];
-    for (let i=0;i<sizes.length;i++){
+    for (let i=0;i<configs.length;i++){
       const meta = TEAM_META[i];
       teams.push({ id:i, name: meta.name, color: meta.color, units: [] });
     }
-    // distribuir ángulos y crear cada equipo con su tamaño
+    // distribuir ángulos y crear cada equipo con su configuración
     for (let i=0;i<teams.length;i++){
       const ang = i * (Math.PI*2 / teams.length);
-      const size = clamp(parseInt(sizes[i])||8, 4, 16);
-      const comp = compositionFor(ui.composition.value, size);
+      const cfg = configs[i] || {};
+      const size = clamp(parseInt(cfg.size)||8, 4, 16);
+      const compKind = cfg.comp || ui.composition.value;
+      const comp = compositionFor(compKind, size);
       spawnTeam(teams[i], comp, ang);
     }
   }

--- a/style.css
+++ b/style.css
@@ -57,6 +57,8 @@ select, input[type="number"]{
   .tag{ display:inline-block; padding:2px 8px; border-radius:999px; font-size:12px; background:rgba(255,255,255,.08); margin-right:6px; }
 .teamRow{ display:flex; align-items:center; gap:8px; margin:6px 0; }
 .dot{ width:10px; height:10px; border-radius:50%; display:inline-block; }
+.teamRow .team-size{ width:60px; flex:0 0 auto; }
+.teamRow .team-comp{ width:150px; flex:0 0 auto; }
 
 /* Nuevas secciones de configuración */
 .settings-section{ margin-top:16px; padding-top:10px; border-top:1px solid rgba(255,255,255,.08); }


### PR DESCRIPTION
## Summary
- add per-team composition dropdown in team settings and style it
- support reading and applying per-team composition in setup and team building
- default team rows to global composition when not specified

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2ff541c88331b4b6cb506eabd7bd