### PR TITLE
Add draggable spawn points for teams

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -28,7 +28,7 @@ export function updateTeamCounts(){
 }
 
 export function setupMatch(){
-  const { simState, ui, clearUnits, buildTeams, allUnits, updateHPBar } = ctx;
+  const { simState, ui, clearUnits, buildTeams, allUnits, updateHPBar, refreshSpawnMarker } = ctx;
   simState.active = false; simState.paused = false;
   ui.start.disabled = false; ui.pause.disabled = true; ui.pause.textContent = "Pausar"; ui.status.textContent = "Preparado.";
 
@@ -48,9 +48,12 @@ export function setupMatch(){
   }
 
   clearUnits();
-  buildTeams(configs);
+  const newTeams = buildTeams(configs);
+  ctx.teams = newTeams;
+  ctx.allUnits = allUnits;
   allUnits.forEach(updateHPBar);
   updateTeamCounts();
+  refreshSpawnMarker && refreshSpawnMarker();
 }
 
 export function selectTarget(u){


### PR DESCRIPTION
## Summary
- Store a spawn `THREE.Vector3` for each team and use it when spawning units
- Enable editing team spawn positions via a draggable marker on the terrain
- Refresh spawn markers after resetting matches

## Testing
- `node --check main.js`
- `node --check ai.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3161b81c8331921275a905c14c90