### PR TITLE
Handle per-team configuration updates in UI

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -19,8 +19,12 @@ export function updateTeamCounts(){
     row.querySelector('.teamName').textContent = t.name;
     const inp = row.querySelector('.team-size');
     inp.value = total;
+    inp.addEventListener('input', setupMatch);
+    inp.addEventListener('change', setupMatch);
     const sel = row.querySelector('.team-comp');
     sel.value = compVal;
+    sel.addEventListener('input', setupMatch);
+    sel.addEventListener('change', setupMatch);
     row.querySelector('.fill').style.width = `${(100*alive/total).toFixed(1)}%`;
     row.querySelector('.team-count').textContent = `${alive}/${total}`;
     box.appendChild(row);

--- a/main.js
+++ b/main.js
@@ -361,6 +361,14 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     setupMatch();
   });
 
+  const handleTeamFieldChange = (e) => {
+    if (e.target.matches('.team-size, .team-comp')) {
+      setupMatch();
+    }
+  };
+  ui.teamsPanel.addEventListener('input', handleTeamFieldChange);
+  ui.teamsPanel.addEventListener('change', handleTeamFieldChange);
+
   ui.teamsPanel.addEventListener('click', (e) => {
     const row = e.target.closest('.teamRow');
     if (!row) return;


### PR DESCRIPTION
## Summary
- Rebuild team rows with input and select listeners that call `setupMatch`
- Delegate change events in the teams panel to keep match configuration in sync

## Testing
- `node --input-type=module <script>` (jsdom simulation of editing team size/comp)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d35b0750083318daeb970d066808c