### PR TITLE
Add UI collapse toggle and expand on battle end

### DIFF
--- a/alias_war.html
+++ b/alias_war.html
@@ -7,10 +7,10 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div id="gameContainer">
-  <canvas id="threeCanvas"></canvas>
+  <div id="gameContainer">
+    <canvas id="threeCanvas"></canvas>
 
-  <div id="ui">
+    <div id="ui">
     <div class="panel top">
       <div class="status" id="statusTxt">Hasta 5 ejércitos, clases con aspecto propio, sanadores -15% de velocidad, estructuras con rango ampliable.</div>
       <div class="hint">Vista satelital inclinada. Click en el canvas para rotar; rueda para zoom; botón derecho para desplazar.</div>
@@ -115,6 +115,7 @@
       <span class="mini">Rueda: zoom — Izq: rotar — Der: desplazar</span>
     </div>
   </div>
+  <button id="toggleUi" title="Mostrar panel">⤢</button>
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>

--- a/main.js
+++ b/main.js
@@ -328,6 +328,8 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
 
   // ======= UI =======
   const ui = {
+    root: document.getElementById('ui'),
+    toggle: document.getElementById('toggleUi'),
     status: document.getElementById('statusTxt'),
     start:  document.getElementById('startBtn'),
     pause:  document.getElementById('pauseBtn'),
@@ -346,6 +348,15 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     rough: document.getElementById('rough'),
     mtn: document.getElementById('mtn'),
   };
+  function collapseUI(){
+    ui.root.classList.add('ui-collapsed');
+    ui.toggle.style.display = 'block';
+  }
+  function expandUI(){
+    ui.root.classList.remove('ui-collapsed');
+    ui.toggle.style.display = 'none';
+  }
+  ui.toggle.addEventListener('click', expandUI);
   ui.speed.addEventListener('input', () => { simState.speedMul = parseFloat(ui.speed.value); ui.speedLbl.textContent = simState.speedMul.toFixed(2) + "x"; });
   ui.satellite.addEventListener('change', () => { controls.satellite = ui.satellite.checked; });
   controls.satellite = ui.satellite.checked;
@@ -403,6 +414,7 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     allUnits.forEach(u => { u.userData.attackT = 0; u.userData.healT = 0; u.userData.isAttacking = false; u.userData.state=""; u.userData.stateT=0; });
     ui.start.disabled = true; ui.pause.disabled = false;
     ui.status.textContent = "¡Batalla en curso!"; log("¡La batalla ha comenzado!");
+    collapseUI();
   });
   ui.pause.addEventListener('click', () => { if (!simState.active) return; simState.paused = !simState.paused; ui.pause.textContent = simState.paused ? "Reanudar" : "Pausar"; ui.status.textContent = simState.paused ? "Batalla pausada" : "¡Batalla en curso!"; });
   ui.reset.addEventListener('click', setupMatch);
@@ -678,6 +690,7 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
       simState.active = false; ui.start.disabled = false; ui.pause.disabled = true;
       const winner = aliveTeams[0];
       ui.status.textContent = winner ? `¡Gana ${winner.name}!` : "Empate";
+      expandUI();
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -11,6 +11,19 @@
   #threeCanvas{ width:100%; height:100%; display:block; cursor: grab; }
   #threeCanvas:active{ cursor: grabbing; }
   #ui{ pointer-events:none; position:absolute; inset:0; z-index:10; }
+  #ui.ui-collapsed .panel{ display:none; }
+  #toggleUi{
+    position:absolute;
+    top:16px; left:16px;
+    z-index:20;
+    padding:8px 12px;
+    border:none;
+    border-radius:10px;
+    background:rgba(10,14,22,.72);
+    color:#e8eef7;
+    cursor:pointer;
+    display:none;
+  }
   .panel{
     pointer-events:auto; position:absolute;
     background: rgba(10,14,22,.72);


### PR DESCRIPTION
## Summary
- Hide UI panels with new `.ui-collapsed` class and floating maximize button
- Add outside `#toggleUi` button to re-open panels when collapsed
- Collapse UI on battle start and expand after battle or via toggle button

## Testing
- `node --check main.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d38d13bb88331ab1e50beb0f2077a