### PR TITLE
Añadir botón fijo para panel de control derecho

### DIFF
--- a/alias_war.html
+++ b/alias_war.html
@@ -115,7 +115,7 @@
       <span class="mini">Rueda: zoom — Izq: rotar — Der: desplazar</span>
     </div>
   </div>
-  <button id="toggleUi" title="Mostrar panel">⤢</button>
+  <button id="toggleUi" title="Minimizar panel">⊟</button>
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>

--- a/main.js
+++ b/main.js
@@ -347,16 +347,23 @@ const { camera, controls } = initCamera(renderer, canvas, simState);
     teamsPanel: document.getElementById('teamsPanel'),
     rough: document.getElementById('rough'),
     mtn: document.getElementById('mtn'),
+    rightPanel: document.querySelector('.panel.right'),
   };
   function collapseUI(){
-    ui.root.classList.add('ui-collapsed');
-    ui.toggle.style.display = 'block';
+    ui.root.classList.add('right-collapsed');
+    ui.toggle.textContent = '⊞';
+    ui.toggle.title = 'Maximizar panel';
   }
   function expandUI(){
-    ui.root.classList.remove('ui-collapsed');
-    ui.toggle.style.display = 'none';
+    ui.root.classList.remove('right-collapsed');
+    ui.toggle.textContent = '⊟';
+    ui.toggle.title = 'Minimizar panel';
   }
-  ui.toggle.addEventListener('click', expandUI);
+  ui.toggle.addEventListener('click', () => {
+    if (ui.root.classList.contains('right-collapsed')) expandUI();
+    else collapseUI();
+  });
+  expandUI();
   ui.speed.addEventListener('input', () => { simState.speedMul = parseFloat(ui.speed.value); ui.speedLbl.textContent = simState.speedMul.toFixed(2) + "x"; });
   ui.satellite.addEventListener('change', () => { controls.satellite = ui.satellite.checked; });
   controls.satellite = ui.satellite.checked;

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
   #threeCanvas{ width:100%; height:100%; display:block; cursor: grab; }
   #threeCanvas:active{ cursor: grabbing; }
   #ui{ pointer-events:none; position:absolute; inset:0; z-index:10; }
-  #ui.ui-collapsed .panel{ display:none; }
+  #ui.right-collapsed .panel.right{ display:none; }
   #toggleUi{
     position:absolute;
     top:16px; left:16px;
@@ -22,7 +22,6 @@
     background:rgba(10,14,22,.72);
     color:#e8eef7;
     cursor:pointer;
-    display:none;
   }
   .panel{
     pointer-events:auto; position:absolute;


### PR DESCRIPTION
## Resumen
- Botón de alternancia siempre visible que minimiza o maximiza solo el panel derecho.
- Estilos ajustados para ocultar únicamente el panel de control derecho.
- Estado y título del botón cambian según el panel esté visible u oculto.

## Pruebas
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3adf7c3483319c50ad52282ddac3