### PR TITLE
Add day-night lighting cycle with adjustable speed

### DIFF
--- a/alias_war.html
+++ b/alias_war.html
@@ -28,6 +28,13 @@
         <div class="switch" style="align-self:end;"><input id="showTrails" type="checkbox" checked/><span>Estelas</span></div>
       </div>
 
+      <div class="row">
+        <div>
+          <div class="kv"><span>Vel. ciclo</span><span class="mini" id="cycleSpeedLbl">1.00x</span></div>
+          <input id="cycleSpeed" type="range" min="0.1" max="5" step="0.1" value="1.0"/>
+        </div>
+      </div>
+
       <div class="settings-section">
         <h4>Configuración global</h4>
 


### PR DESCRIPTION
## Summary
- Track `timeOfDay` and update ambient and directional lights with trigonometric day/night cycle
- Rotate directional light to simulate sun movement and blend colors/intensities
- Add UI slider to control cycle speed

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_689d3d328ef48331974cff60c576964d